### PR TITLE
Implement watchlist sync for download systems

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Jellyfin.Plugin.JellyNext/
 ├── Providers/              # Content provider implementations (IContentProvider)
 ├── Resources/              # Embedded resources (dummy.mp4)
 ├── ScheduledTasks/         # Background tasks (ContentSyncScheduledTask.cs)
-├── Services/               # Business logic (TraktApi, ContentSync, Radarr/Sonarr, Jellyseerr, etc.)
+├── Services/                   # Business logic (TraktApi, ContentSync, WatchlistSync, Radarr/Sonarr, Jellyseerr, etc.)
 │   └── DownloadProviders/  # IDownloadProvider, NativeDownloadProvider, JellyseerrDownloadProvider, WebhookDownloadProvider
 ├── VirtualLibrary/         # Virtual library system (Manager, Creator, ContentType)
 ├── Plugin.cs               # Main entry point
@@ -57,8 +57,9 @@ Jellyfin.Plugin.JellyNext/
 - **Virtual Libraries**: Per-user .strm stub files (`jellynext-virtual/[userId]/[content-type]/`) + global content (`jellynext-virtual/global/[content-type]/`)
 - **Download Providers** (`IDownloadProvider`): Pluggable download backends (NativeDownloadProvider for direct Radarr/Sonarr, JellyseerrDownloadProvider for Jellyseerr API, WebhookDownloadProvider for custom HTTP webhooks)
 - **Playback Interception**: Detects virtual item playback, triggers downloads via selected provider
+- **Watchlist Sync**: Automatically adds watchlisted movies/shows from Trakt to download systems (Radarr/Sonarr/Jellyseerr)
 - **OAuth**: Per-user Trakt tokens with auto-refresh (stored in `PluginConfiguration.TraktUsers[]`)
-- **Sync System**: `ContentSyncScheduledTask` + `StartupSyncService` → cache → .strm files → library scan
+- **Sync System**: `ContentSyncScheduledTask` + `WatchlistSyncScheduledTask` + `StartupSyncService` → cache → .strm files → library scan
 
 ### Architectural Layers
 ```
@@ -94,10 +95,11 @@ Plugin Entry → API Controllers → Services → Providers → Virtual Library 
 - `ContentCacheService.cs`: In-memory cache for content items (per-user, per-provider, 6hr expiration)
 - `ShowsCacheService.cs`: **Global season-level cache** + **per-user watch progress tracking**. Supports full sync (first run via `/sync/watched/shows`) and incremental sync (subsequent runs via `/sync/history/shows` with timestamps). Automatically handles ended vs ongoing shows, caching all seasons for ended shows and only complete seasons for ongoing shows. Tracks last sync timestamp in-memory for efficient delta syncing.
 - `ContentSyncService.cs`: Sync orchestrator (iterates users/providers, updates cache/virtual library)
+- `WatchlistSyncService.cs`: Watchlist sync orchestrator (fetches Trakt watchlists, filters against local library, triggers downloads via DownloadProviderFactory)
 - `JellyseerrService.cs`: Jellyseerr API client (user import/management, movie/TV requests, server/profile retrieval)
 - `RadarrService.cs`: Radarr API client (movie search/add) - native integration only
 - `SonarrService.cs`: Sonarr API client (series search/add, per-season monitoring, anime detection) - native integration only
-- `LocalLibraryService.cs`: Jellyfin library queries (find series by TVDB ID, exclude virtual items)
+- `LocalLibraryService.cs`: Jellyfin library queries (find series by TVDB ID, check movie existence by TMDB ID, exclude virtual items)
 - `PlaybackInterceptor.cs`: IHostedService detecting virtual item playback, uses DownloadProviderFactory to route requests
 - `DownloadProviderFactory.cs`: Factory selecting NativeDownloadProvider, JellyseerrDownloadProvider, or WebhookDownloadProvider based on config
 
@@ -115,6 +117,7 @@ Plugin Entry → API Controllers → Services → Providers → Virtual Library 
 
 **Jellyfin Integration**:
 - `ScheduledTasks/ContentSyncScheduledTask.cs`: IScheduledTask (6hr interval, calls ContentSyncService, triggers library scan)
+- `ScheduledTasks/WatchlistSyncScheduledTask.cs`: IScheduledTask (1hr interval, calls WatchlistSyncService, auto-adds watchlisted items to download systems)
 
 **Configuration**:
 - `Configuration/PluginConfiguration.cs`: Persisted settings (Radarr/Sonarr config, TraktUsers[], cache expiration). Profile IDs are nullable `int?` to support optional configs.
@@ -183,7 +186,8 @@ Background: Plugin.PollingTasks[userGuid] = TraktApi.PollForTokenAsync()
 
 ### Per-User Architecture
 - Each user has own Trakt OAuth token (stored in `PluginConfiguration.TraktUsers[]`)
-- Per-user sync settings: `SyncMovieRecommendations`, `SyncShowRecommendations`, `SyncNextSeasons`, `IgnoreCollected`, `IgnoreWatchlisted`, `LimitShowsToSeasonOne`, `MovieRecommendationsLimit`, `ShowRecommendationsLimit`, `LastHistorySyncTimestamp` (all in `TraktUser` model)
+- Per-user sync settings: `SyncMovieRecommendations`, `SyncShowRecommendations`, `SyncNextSeasons`, `SyncWatchlistMovies`, `SyncWatchlistShows`, `IgnoreCollected`, `IgnoreWatchlisted`, `LimitShowsToSeasonOne`, `MovieRecommendationsLimit`, `ShowRecommendationsLimit`, `LastHistorySyncTimestamp` (all in `TraktUser` model)
+- Watchlist tracking: `ProcessedWatchlistMovieIds` (TMDB IDs), `ProcessedWatchlistShowIds` (TVDB IDs) - persisted to avoid re-adding same items
 - Recommendation limits: User-configurable 1-100 (default: 50), validated with `Math.Clamp()` on save
 - Virtual libraries filtered by userId extracted from path
 - Access via `UserHelper.GetTraktUser(userGuid)`
@@ -238,6 +242,29 @@ Implement `IContentProvider` + register in `PluginServiceRegistrator` → automa
 - **Cache-only reads**: Retrieves watched progress + season metadata entirely from ShowsCacheService (no duplicate API calls)
 - **Dynamic fetching**: If next season not in cache for ongoing shows, fetches latest from Trakt API via `GetShowSeasons()` and checks season count
 - **Library deduplication**: Uses LocalLibraryService to exclude shows already in Jellyfin library (TVDB ID matching)
+
+### Watchlist Sync (Auto-Download)
+- **Purpose**: Automatically adds watchlisted movies/shows from Trakt to download systems (Radarr/Sonarr/Jellyseerr)
+- **Per-user setting**: Controlled by `SyncWatchlistMovies` and `SyncWatchlistShows` flags in `TraktUser`
+- **Architecture**:
+  - `WatchlistSyncService`: Orchestrates watchlist fetching, library deduplication, and download triggering
+  - `WatchlistSyncScheduledTask`: IScheduledTask running every 1 hour (more frequent than content sync due to dynamic watchlist changes)
+  - Uses `DownloadProviderFactory` for routing to Native/Jellyseerr/Webhook modes (same as playback interception)
+- **Workflow**:
+  1. Fetch movies via `TraktApi.GetMovieWatchlist()` and shows via `TraktApi.GetShowWatchlist()`
+  2. Filter out items already in local library (`LocalLibraryService.DoesMovieExist()` / `FindSeriesByTvdbId()`)
+  3. Filter out items already processed (`ProcessedWatchlistMovieIds` / `ProcessedWatchlistShowIds` HashSets)
+  4. Trigger download via appropriate provider (`IDownloadProvider.RequestMovieAsync()` / `RequestShowAsync()`)
+  5. Add to processed IDs to prevent re-adding on subsequent syncs
+  6. Save configuration to persist processed IDs
+- **Show handling**: Adds Season 1 by default (Trakt watchlist doesn't specify specific seasons)
+- **State tracking**: 
+  - `ProcessedWatchlistMovieIds`: HashSet<int> of TMDB IDs (persisted in config)
+  - `ProcessedWatchlistShowIds`: HashSet<int> of TVDB IDs (persisted in config)
+  - Reset manually by removing IDs from config if you want to re-trigger downloads
+- **API endpoints**: Uses `/sync/watchlist/movies` and `/sync/watchlist/shows` with `extended=full` for genre metadata
+- **Throttling**: 1 second delay between downloads to avoid overwhelming download systems
+- **Error handling**: Individual item failures logged, don't stop entire sync process
 
 ### Shows Cache (Season-Level)
 - **Purpose**: Hybrid caching system with global show/season metadata + per-user watch progress tracking

--- a/Jellyfin.Plugin.JellyNext/Api/TraktController.cs
+++ b/Jellyfin.Plugin.JellyNext/Api/TraktController.cs
@@ -151,6 +151,8 @@ public class TraktController : ControllerBase
             syncMovieRecommendations = traktUser.SyncMovieRecommendations,
             syncShowRecommendations = traktUser.SyncShowRecommendations,
             syncNextSeasons = traktUser.SyncNextSeasons,
+            syncWatchlistMovies = traktUser.SyncWatchlistMovies,
+            syncWatchlistShows = traktUser.SyncWatchlistShows,
             ignoreCollected = traktUser.IgnoreCollected,
             ignoreWatchlisted = traktUser.IgnoreWatchlisted,
             limitShowsToSeasonOne = traktUser.LimitShowsToSeasonOne,
@@ -180,6 +182,8 @@ public class TraktController : ControllerBase
         traktUser.SyncMovieRecommendations = settings.SyncMovieRecommendations;
         traktUser.SyncShowRecommendations = settings.SyncShowRecommendations;
         traktUser.SyncNextSeasons = settings.SyncNextSeasons;
+        traktUser.SyncWatchlistMovies = settings.SyncWatchlistMovies;
+        traktUser.SyncWatchlistShows = settings.SyncWatchlistShows;
         traktUser.IgnoreCollected = settings.IgnoreCollected;
         traktUser.IgnoreWatchlisted = settings.IgnoreWatchlisted;
         traktUser.LimitShowsToSeasonOne = settings.LimitShowsToSeasonOne;
@@ -237,5 +241,15 @@ public class TraktController : ControllerBase
         /// Gets or sets the number of show recommendations to fetch (1-100).
         /// </summary>
         public int ShowRecommendationsLimit { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to automatically add watchlisted movies to download system.
+        /// </summary>
+        public bool SyncWatchlistMovies { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to automatically add watchlisted shows to download system.
+        /// </summary>
+        public bool SyncWatchlistShows { get; set; }
     }
 }

--- a/Jellyfin.Plugin.JellyNext/Configuration/tabs/trakt.html
+++ b/Jellyfin.Plugin.JellyNext/Configuration/tabs/trakt.html
@@ -57,6 +57,24 @@
                         Enable next season suggestions for this user
                     </div>
                 </div>
+                <div class="checkboxContainer checkboxContainer-withDescription">
+                    <label>
+                        <input is="emby-checkbox" type="checkbox" id="UserSyncWatchlistMovies" />
+                        <span>Auto-Add Watchlisted Movies</span>
+                    </label>
+                    <div class="fieldDescription checkboxFieldDescription">
+                        Automatically add movies from Trakt watchlist to download system (Radarr/Jellyseerr)
+                    </div>
+                </div>
+                <div class="checkboxContainer checkboxContainer-withDescription">
+                    <label>
+                        <input is="emby-checkbox" type="checkbox" id="UserSyncWatchlistShows" />
+                        <span>Auto-Add Watchlisted Shows</span>
+                    </label>
+                    <div class="fieldDescription checkboxFieldDescription">
+                        Automatically add shows from Trakt watchlist to download system (Sonarr/Jellyseerr)
+                    </div>
+                </div>
 
                 <h4 class="sectionTitle" style="font-size: 1em; margin-top: 1.5em;">Recommendation Limits</h4>
                 <div class="inputContainer">

--- a/Jellyfin.Plugin.JellyNext/Configuration/tabs/trakt.js
+++ b/Jellyfin.Plugin.JellyNext/Configuration/tabs/trakt.js
@@ -131,6 +131,8 @@ function loadUserSettings() {
         document.getElementById('UserSyncMovieRecommendations').checked = settings.syncMovieRecommendations !== false;
         document.getElementById('UserSyncShowRecommendations').checked = settings.syncShowRecommendations !== false;
         document.getElementById('UserSyncNextSeasons').checked = settings.syncNextSeasons !== false;
+        document.getElementById('UserSyncWatchlistMovies').checked = settings.syncWatchlistMovies === true;
+        document.getElementById('UserSyncWatchlistShows').checked = settings.syncWatchlistShows === true;
         document.getElementById('UserIgnoreCollected').checked = settings.ignoreCollected !== false;
         document.getElementById('UserIgnoreWatchlisted').checked = settings.ignoreWatchlisted === true;
         document.getElementById('UserLimitShowsToSeasonOne').checked = settings.limitShowsToSeasonOne !== false;
@@ -177,6 +179,8 @@ function saveUserTraktSettings(userGuid) {
         syncMovieRecommendations: document.getElementById('UserSyncMovieRecommendations').checked,
         syncShowRecommendations: document.getElementById('UserSyncShowRecommendations').checked,
         syncNextSeasons: document.getElementById('UserSyncNextSeasons').checked,
+        syncWatchlistMovies: document.getElementById('UserSyncWatchlistMovies').checked,
+        syncWatchlistShows: document.getElementById('UserSyncWatchlistShows').checked,
         ignoreCollected: document.getElementById('UserIgnoreCollected').checked,
         ignoreWatchlisted: document.getElementById('UserIgnoreWatchlisted').checked,
         limitShowsToSeasonOne: document.getElementById('UserLimitShowsToSeasonOne').checked,

--- a/Jellyfin.Plugin.JellyNext/Models/Trakt/TraktUser.cs
+++ b/Jellyfin.Plugin.JellyNext/Models/Trakt/TraktUser.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Jellyfin.Plugin.JellyNext.Models.Trakt;
 
@@ -71,4 +72,26 @@ public class TraktUser
     /// Gets or sets the number of show recommendations to fetch (1-100).
     /// </summary>
     public int ShowRecommendationsLimit { get; set; } = 50;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to automatically add watchlisted movies to Radarr/Sonarr/Jellyseerr.
+    /// </summary>
+    public bool SyncWatchlistMovies { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to automatically add watchlisted shows to Radarr/Sonarr/Jellyseerr.
+    /// </summary>
+    public bool SyncWatchlistShows { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets the set of movie TMDB IDs that have been processed from the watchlist.
+    /// Used to avoid re-adding the same items on subsequent syncs.
+    /// </summary>
+    public HashSet<int> ProcessedWatchlistMovieIds { get; set; } = new HashSet<int>();
+
+    /// <summary>
+    /// Gets or sets the set of show TVDB IDs that have been processed from the watchlist.
+    /// Used to avoid re-adding the same items on subsequent syncs.
+    /// </summary>
+    public HashSet<int> ProcessedWatchlistShowIds { get; set; } = new HashSet<int>();
 }

--- a/Jellyfin.Plugin.JellyNext/Models/Trakt/TraktWatchlistMovieItem.cs
+++ b/Jellyfin.Plugin.JellyNext/Models/Trakt/TraktWatchlistMovieItem.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace Jellyfin.Plugin.JellyNext.Models.Trakt;
+
+/// <summary>
+/// Represents a watchlist movie item from Trakt API.
+/// </summary>
+public class TraktWatchlistMovieItem
+{
+    /// <summary>
+    /// Gets or sets when the item was added to the watchlist.
+    /// </summary>
+    [JsonPropertyName("listed_at")]
+    public DateTime ListedAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the movie.
+    /// </summary>
+    [JsonPropertyName("movie")]
+    public TraktMovie Movie { get; set; } = new TraktMovie();
+}

--- a/Jellyfin.Plugin.JellyNext/Models/Trakt/TraktWatchlistShowItem.cs
+++ b/Jellyfin.Plugin.JellyNext/Models/Trakt/TraktWatchlistShowItem.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace Jellyfin.Plugin.JellyNext.Models.Trakt;
+
+/// <summary>
+/// Represents a watchlist show item from Trakt API.
+/// </summary>
+public class TraktWatchlistShowItem
+{
+    /// <summary>
+    /// Gets or sets when the item was added to the watchlist.
+    /// </summary>
+    [JsonPropertyName("listed_at")]
+    public DateTime ListedAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the show.
+    /// </summary>
+    [JsonPropertyName("show")]
+    public TraktShow Show { get; set; } = new TraktShow();
+}

--- a/Jellyfin.Plugin.JellyNext/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.JellyNext/PluginServiceRegistrator.cs
@@ -37,8 +37,9 @@ public class PluginServiceRegistrator : IPluginServiceRegistrator
         serviceCollection.AddSingleton<IContentProvider, NextSeasonsProvider>();
         serviceCollection.AddSingleton<IContentProvider, TrendingMoviesProvider>();
 
-        // Sync service (must be registered after providers)
+        // Sync services (must be registered after providers)
         serviceCollection.AddSingleton<ContentSyncService>();
+        serviceCollection.AddSingleton<WatchlistSyncService>();
 
         // Virtual library
         serviceCollection.AddSingleton<VirtualLibrary.VirtualLibraryManager>();

--- a/Jellyfin.Plugin.JellyNext/ScheduledTasks/WatchlistSyncScheduledTask.cs
+++ b/Jellyfin.Plugin.JellyNext/ScheduledTasks/WatchlistSyncScheduledTask.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyNext.Services;
+using MediaBrowser.Model.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.JellyNext.ScheduledTasks;
+
+/// <summary>
+/// Scheduled task for syncing Trakt watchlists and automatically adding items to download systems.
+/// </summary>
+public class WatchlistSyncScheduledTask : IScheduledTask
+{
+    private readonly ILogger<WatchlistSyncScheduledTask> _logger;
+    private readonly WatchlistSyncService _syncService;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WatchlistSyncScheduledTask"/> class.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="syncService">The watchlist sync service.</param>
+    public WatchlistSyncScheduledTask(
+        ILogger<WatchlistSyncScheduledTask> logger,
+        WatchlistSyncService syncService)
+    {
+        _logger = logger;
+        _syncService = syncService;
+    }
+
+    /// <inheritdoc />
+    public string Name => "Sync Trakt Watchlists";
+
+    /// <inheritdoc />
+    public string Key => "JellyNextWatchlistSync";
+
+    /// <inheritdoc />
+    public string Description => "Automatically adds watchlisted movies and shows to Radarr/Sonarr/Jellyseerr";
+
+    /// <inheritdoc />
+    public string Category => "JellyNext";
+
+    /// <inheritdoc />
+    public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Starting scheduled watchlist sync");
+
+        try
+        {
+            progress?.Report(0);
+            await _syncService.SyncAllAsync(cancellationToken);
+            progress?.Report(100);
+
+            _logger.LogInformation("Scheduled watchlist sync completed successfully");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error during scheduled watchlist sync");
+            throw;
+        }
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<TaskTriggerInfo> GetDefaultTriggers()
+    {
+        // Run every 1 hour by default (watchlists change more frequently than recommendations)
+        return new[]
+        {
+            new TaskTriggerInfo
+            {
+                Type = TaskTriggerInfoType.IntervalTrigger,
+                IntervalTicks = TimeSpan.FromHours(1).Ticks
+            }
+        };
+    }
+}

--- a/Jellyfin.Plugin.JellyNext/Services/LocalLibraryService.cs
+++ b/Jellyfin.Plugin.JellyNext/Services/LocalLibraryService.cs
@@ -50,6 +50,30 @@ public class LocalLibraryService
     }
 
     /// <summary>
+    /// Finds a movie in the local library by TMDB ID.
+    /// </summary>
+    /// <param name="tmdbId">The TMDB ID.</param>
+    /// <returns>True if the movie exists in the library, false otherwise.</returns>
+    public bool DoesMovieExist(int tmdbId)
+    {
+        var tmdbIdString = tmdbId.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+        var allItems = _libraryManager.GetItemList(new InternalItemsQuery
+        {
+            IncludeItemTypes = new[] { BaseItemKind.Movie },
+            HasAnyProviderId = new Dictionary<string, string>
+            {
+                { MetadataProvider.Tmdb.ToString(), tmdbIdString }
+            },
+            Recursive = true
+        });
+
+        return allItems
+            .Where(m => !m.Path?.Contains("jellynext-virtual", StringComparison.OrdinalIgnoreCase) ?? true)
+            .Any();
+    }
+
+    /// <summary>
     /// Gets the season numbers that exist locally for a series.
     /// </summary>
     /// <param name="series">The series.</param>

--- a/Jellyfin.Plugin.JellyNext/Services/TraktApi.cs
+++ b/Jellyfin.Plugin.JellyNext/Services/TraktApi.cs
@@ -429,6 +429,64 @@ public class TraktApi
     }
 
     /// <summary>
+    /// Gets the user's movie watchlist.
+    /// </summary>
+    /// <param name="traktUser">The Trakt user configuration.</param>
+    /// <returns>List of watchlisted movies.</returns>
+    public async Task<TraktMovie[]> GetMovieWatchlist(TraktUser traktUser)
+    {
+        using var httpClient = await CreateTraktClient(traktUser);
+        var response = await httpClient.GetAsync("/sync/watchlist/movies?extended=full");
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorContent = await response.Content.ReadAsStringAsync();
+            _logger.LogError(
+                "Failed to get movie watchlist: Status={Status}, Content={Content}",
+                response.StatusCode,
+                errorContent);
+            return Array.Empty<TraktMovie>();
+        }
+
+        var watchlistItems = await response.Content.ReadFromJsonAsync<TraktWatchlistMovieItem[]>(_jsonOptions);
+        if (watchlistItems == null)
+        {
+            return Array.Empty<TraktMovie>();
+        }
+
+        return watchlistItems.Select(item => item.Movie).ToArray();
+    }
+
+    /// <summary>
+    /// Gets the user's show watchlist.
+    /// </summary>
+    /// <param name="traktUser">The Trakt user configuration.</param>
+    /// <returns>List of watchlisted shows.</returns>
+    public async Task<TraktShow[]> GetShowWatchlist(TraktUser traktUser)
+    {
+        using var httpClient = await CreateTraktClient(traktUser);
+        var response = await httpClient.GetAsync("/sync/watchlist/shows?extended=full");
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorContent = await response.Content.ReadAsStringAsync();
+            _logger.LogError(
+                "Failed to get show watchlist: Status={Status}, Content={Content}",
+                response.StatusCode,
+                errorContent);
+            return Array.Empty<TraktShow>();
+        }
+
+        var watchlistItems = await response.Content.ReadFromJsonAsync<TraktWatchlistShowItem[]>(_jsonOptions);
+        if (watchlistItems == null)
+        {
+            return Array.Empty<TraktShow>();
+        }
+
+        return watchlistItems.Select(item => item.Show).ToArray();
+    }
+
+    /// <summary>
     /// Gets watch history for shows with automatic pagination and date filtering.
     /// Fetches all pages automatically until no more results are available.
     /// </summary>

--- a/Jellyfin.Plugin.JellyNext/Services/WatchlistSyncService.cs
+++ b/Jellyfin.Plugin.JellyNext/Services/WatchlistSyncService.cs
@@ -1,0 +1,347 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyNext.Helpers;
+using Jellyfin.Plugin.JellyNext.Models.Common;
+using Jellyfin.Plugin.JellyNext.Services.DownloadProviders;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.JellyNext.Services;
+
+/// <summary>
+/// Service for syncing Trakt watchlists and automatically adding items to download systems.
+/// </summary>
+public class WatchlistSyncService
+{
+    private readonly ILogger<WatchlistSyncService> _logger;
+    private readonly TraktApi _traktApi;
+    private readonly LocalLibraryService _localLibrary;
+    private readonly DownloadProviderFactory _downloadProviderFactory;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WatchlistSyncService"/> class.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="traktApi">The Trakt API service.</param>
+    /// <param name="localLibrary">The local library service.</param>
+    /// <param name="downloadProviderFactory">The download provider factory.</param>
+    public WatchlistSyncService(
+        ILogger<WatchlistSyncService> logger,
+        TraktApi traktApi,
+        LocalLibraryService localLibrary,
+        DownloadProviderFactory downloadProviderFactory)
+    {
+        _logger = logger;
+        _traktApi = traktApi;
+        _localLibrary = localLibrary;
+        _downloadProviderFactory = downloadProviderFactory;
+    }
+
+    /// <summary>
+    /// Syncs watchlists for all users with watchlist sync enabled.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the async operation.</returns>
+    public async Task SyncAllAsync(CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Starting watchlist sync for all users");
+
+        var config = Plugin.Instance?.Configuration;
+        if (config == null)
+        {
+            _logger.LogError("Plugin configuration not available");
+            return;
+        }
+
+        var traktUsers = config.GetAllTraktUsers();
+        if (traktUsers.Count == 0)
+        {
+            _logger.LogInformation("No Trakt users configured, skipping watchlist sync");
+            return;
+        }
+
+        var syncTasks = new List<Task>();
+        foreach (var traktUser in traktUsers)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                break;
+            }
+
+            // Check if watchlist sync is enabled for this user
+            if (!traktUser.SyncWatchlistMovies && !traktUser.SyncWatchlistShows)
+            {
+                continue;
+            }
+
+            syncTasks.Add(SyncUserAsync(traktUser.LinkedMbUserId, cancellationToken));
+        }
+
+        await Task.WhenAll(syncTasks);
+
+        _logger.LogInformation("Completed watchlist sync for all users");
+    }
+
+    /// <summary>
+    /// Syncs watchlist for a specific user.
+    /// </summary>
+    /// <param name="userId">The user ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the async operation.</returns>
+    public async Task SyncUserAsync(Guid userId, CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Starting watchlist sync for user {UserId}", userId);
+
+        var traktUser = UserHelper.GetTraktUser(userId);
+        if (traktUser == null)
+        {
+            _logger.LogWarning("No Trakt user found for {UserId}", userId);
+            return;
+        }
+
+        var addedMovies = 0;
+        var addedShows = 0;
+
+        try
+        {
+            // Sync movies
+            if (traktUser.SyncWatchlistMovies)
+            {
+                addedMovies = await SyncMovieWatchlistAsync(traktUser, cancellationToken);
+            }
+
+            // Sync shows
+            if (traktUser.SyncWatchlistShows)
+            {
+                addedShows = await SyncShowWatchlistAsync(traktUser, cancellationToken);
+            }
+
+            // Save updated processed IDs
+            Plugin.Instance?.SaveConfiguration();
+
+            _logger.LogInformation(
+                "Completed watchlist sync for user {UserId}: {AddedMovies} movies, {AddedShows} shows added",
+                userId,
+                addedMovies,
+                addedShows);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error syncing watchlist for user {UserId}", userId);
+        }
+    }
+
+    private async Task<int> SyncMovieWatchlistAsync(
+        Models.Trakt.TraktUser traktUser,
+        CancellationToken cancellationToken = default)
+    {
+        var addedCount = 0;
+
+        try
+        {
+            var watchlistMovies = await _traktApi.GetMovieWatchlist(traktUser);
+            _logger.LogInformation(
+                "Found {Count} movies in watchlist for user {UserId}",
+                watchlistMovies.Length,
+                traktUser.LinkedMbUserId);
+
+            if (watchlistMovies.Length > 0)
+            {
+                _logger.LogInformation(
+                    "Watchlist movies: {Movies}",
+                    string.Join(", ", watchlistMovies.Select(m => $"{m.Title} ({m.Year}) [TMDB: {m.Ids.Tmdb}]")));
+            }
+
+            var downloadProvider = _downloadProviderFactory.GetProvider();
+
+            foreach (var movie in watchlistMovies)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
+
+                if (!movie.Ids.Tmdb.HasValue)
+                {
+                    _logger.LogWarning(
+                        "Skipping movie {Title} ({Year}): No TMDB ID available",
+                        movie.Title,
+                        movie.Year);
+                    continue;
+                }
+
+                var tmdbId = movie.Ids.Tmdb.Value;
+
+                // Check if already in library
+                if (_localLibrary.DoesMovieExist(tmdbId))
+                {
+                    _logger.LogInformation(
+                        "Skipping movie {Title} ({Year}): Already in library",
+                        movie.Title,
+                        movie.Year);
+                    continue;
+                }
+
+                // Add to download system
+                _logger.LogInformation(
+                    "Adding movie {Title} ({Year}) to download queue",
+                    movie.Title,
+                    movie.Year);
+
+                var contentItem = new ContentItem
+                {
+                    Type = ContentType.Movie,
+                    Title = movie.Title,
+                    Year = movie.Year,
+                    TmdbId = tmdbId,
+                    ImdbId = movie.Ids.Imdb,
+                    TraktId = movie.Ids.Trakt,
+                    ProviderName = "Watchlist",
+                    Genres = movie.Genres
+                };
+
+                var result = await downloadProvider.RequestMovieAsync(contentItem, traktUser.LinkedMbUserId.ToString());
+
+                if (result.Success)
+                {
+                    _logger.LogInformation(
+                        "Successfully added movie {Title} ({Year}): {Message}",
+                        movie.Title,
+                        movie.Year,
+                        result.Message);
+                    addedCount++;
+                }
+                else
+                {
+                    _logger.LogError(
+                        "Failed to add movie {Title} ({Year}): {Message}",
+                        movie.Title,
+                        movie.Year,
+                        result.Message);
+                }
+
+                // Small delay to avoid overwhelming the download system
+                await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error syncing movie watchlist for user {UserId}", traktUser.LinkedMbUserId);
+        }
+
+        return addedCount;
+    }
+
+    private async Task<int> SyncShowWatchlistAsync(
+        Models.Trakt.TraktUser traktUser,
+        CancellationToken cancellationToken = default)
+    {
+        var addedCount = 0;
+
+        try
+        {
+            var watchlistShows = await _traktApi.GetShowWatchlist(traktUser);
+            _logger.LogInformation(
+                "Found {Count} shows in watchlist for user {UserId}",
+                watchlistShows.Length,
+                traktUser.LinkedMbUserId);
+
+            if (watchlistShows.Length > 0)
+            {
+                _logger.LogInformation(
+                    "Watchlist shows: {Shows}",
+                    string.Join(", ", watchlistShows.Select(s => $"{s.Title} ({s.Year}) [TVDB: {s.Ids.Tvdb}]")));
+            }
+
+            var downloadProvider = _downloadProviderFactory.GetProvider();
+
+            foreach (var show in watchlistShows)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
+
+                if (!show.Ids.Tvdb.HasValue)
+                {
+                    _logger.LogWarning(
+                        "Skipping show {Title} ({Year}): No TVDB ID available",
+                        show.Title,
+                        show.Year);
+                    continue;
+                }
+
+                var tvdbId = show.Ids.Tvdb.Value;
+
+                // Check if already in library (any season)
+                var existingSeries = _localLibrary.FindSeriesByTvdbId(tvdbId);
+                if (existingSeries != null)
+                {
+                    _logger.LogInformation(
+                        "Skipping show {Title} ({Year}): Already in library",
+                        show.Title,
+                        show.Year);
+                    continue;
+                }
+
+                // Add to download system (Season 1 by default, as Trakt doesn't specify specific seasons in watchlist)
+                _logger.LogInformation(
+                    "Adding show {Title} ({Year}) Season 1 to download queue",
+                    show.Title,
+                    show.Year);
+
+                var contentItem = new ContentItem
+                {
+                    Type = ContentType.Show,
+                    Title = show.Title,
+                    Year = show.Year,
+                    TvdbId = tvdbId,
+                    TmdbId = show.Ids.Tmdb,
+                    ImdbId = show.Ids.Imdb,
+                    TraktId = show.Ids.Trakt,
+                    SeasonNumber = 1,
+                    ProviderName = "Watchlist",
+                    Genres = show.Genres
+                };
+
+                // Check if this is anime (for routing to anime folder/profile)
+                var isAnime = show.Genres?.Any(g => g.Equals("anime", StringComparison.OrdinalIgnoreCase)) == true;
+
+                var result = await downloadProvider.RequestShowAsync(
+                    contentItem,
+                    seasonNumber: 1,
+                    playerId: traktUser.LinkedMbUserId.ToString(),
+                    isAnime: isAnime);
+
+                if (result.Success)
+                {
+                    _logger.LogInformation(
+                        "Successfully added show {Title} ({Year}) Season 1: {Message}",
+                        show.Title,
+                        show.Year,
+                        result.Message);
+                    addedCount++;
+                }
+                else
+                {
+                    _logger.LogError(
+                        "Failed to add show {Title} ({Year}) Season 1: {Message}",
+                        show.Title,
+                        show.Year,
+                        result.Message);
+                }
+
+                // Small delay to avoid overwhelming the download system
+                await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error syncing show watchlist for user {UserId}", traktUser.LinkedMbUserId);
+        }
+
+        return addedCount;
+    }
+}


### PR DESCRIPTION
## Automatic Trakt Watchlist Sync

Adds automatic synchronization of Trakt watchlists to download systems (Radarr/Sonarr/Jellyseerr).

### Features

- Automatically adds watchlisted movies and shows to configured download system
- Background sync task runs every 1 hour (configurable via Scheduled Tasks)
- Per-user enable/disable controls via Trakt tab
- Smart library deduplication - skips items already in Jellyfin
- Works with all download integration modes (Native, Jellyseerr, Webhook)
- TV shows default to Season 1 (Trakt watchlist doesn't specify seasons)
- Anime detection and routing to separate profiles/folders
- 1-second throttling between requests to prevent overwhelming systems
- No persistent cache - allows re-requesting declined/failed items by keeping them in watchlist

### New Components

**Services:**
- `WatchlistSyncService` - Orchestrates watchlist fetching and download requests
- `WatchlistSyncScheduledTask` - Background task (1 hour interval)

**API Methods:**
- `TraktApi.GetMovieWatchlist()` / `GetShowWatchlist()`
- `LocalLibraryService.DoesMovieExist()`

**Models:**
- `TraktWatchlistMovieItem`, `TraktWatchlistShowItem`

**Configuration (per-user):**
- `TraktUser.SyncWatchlistMovies` - Enable movie watchlist sync
- `TraktUser.SyncWatchlistShows` - Enable show watchlist sync

### UI Changes

New checkboxes in Trakt tab:
- Auto-Add Watchlisted Movies
- Auto-Add Watchlisted Shows

<img width="1457" height="968" alt="image" src="https://github.com/user-attachments/assets/ce9b19b6-9bbf-4a3e-b6fe-f2d4e0b6be45" />

New auto-scheduled task:
<img width="1636" height="429" alt="image" src="https://github.com/user-attachments/assets/31cbf4c6-bbac-4368-a483-ea496d0df7e0" />

---

Addresses #17.